### PR TITLE
Hotfix/Services Sentry logger

### DIFF
--- a/helm/chart/files/services.conf
+++ b/helm/chart/files/services.conf
@@ -15,20 +15,9 @@
       service_name ${tag_parts[1]}
     </record>
   </filter>
-  <match services.**>
-    @type copy
-    <store>
-      @type relabel
-      @label @SERVICES_SLACK_LOG
-    </store>
-    <store>
-      @type relabel
-      @label @SERVICES_SENTRY_LOG
-    </store>
-  </match>
 </label>
 
-<label @SERVICES_SLACK_LOG>
+<label @SERVICES_LOG>
   <match services.**>
     # https://github.com/sowawa/fluent-plugin-slack
     @type slack
@@ -41,23 +30,5 @@
     message_keys message
     # Upload events regularly
     flush_interval 5s
-  </match>
-</label>
-
-<label @SERVICES_SENTRY_LOG>
-  <filter services.**>
-    @type record_transformer
-    enable_ruby true
-    <record>
-      # Custom Sentry tags
-      # https://github.com/y-ken/fluent-plugin-sentry/blob/master/lib/fluent/plugin/out_sentry.rb
-      tags ${{"service_name"=>record["service_name"], "module_name"=>record["name"]}}
-    </record>
-  </filter>
-  <match services.**>
-    @type sentry
-    endpoint_url "#{ENV['FLUENTD__SENTRY_URL']}"
-    # Upload events regularly
-    flush_interval 10s
   </match>
 </label>


### PR DESCRIPTION
Reduce audience of services `fluentd` logger to Slack only (for alerts mainly).