### PR TITLE
Hotfix/containerd-log-format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CircleCI](https://circleci.com/gh/noosenergy/noos-kube-logs.svg?style=svg&circle-token=8658731bfa70cd9619d715b982fc3f4684760beb)](https://circleci.com/gh/noosenergy/noos-kube-logs)
+[![CircleCI](https://circleci.com/gh/noosenergy/noos-kube-logs.svg?style=svg&circle-token=e01ef89adb6911ad8aa3247ad426ad538cb10889)](https://circleci.com/gh/noosenergy/noos-kube-logs)
 
 # Noos Kube Logs
 Logs monitoring boilerplate for the Noos platform.

--- a/helm/chart/files/kubernetes.conf
+++ b/helm/chart/files/kubernetes.conf
@@ -11,11 +11,22 @@
   # Tag required by default
   tag kubernetes.*
   <parse>
-    @type json
-    time_key time
-    time_type string
-    time_format "%Y-%m-%dT%H:%M:%S.%NZ"
-    keep_time_key false
+    @type multi_format
+    # For docker CRI (for EKS < v1.24)
+    <pattern>
+      format json
+      time_key time
+      time_type string
+      time_format "%Y-%m-%dT%H:%M:%S.%NZ"
+      keep_time_key true
+    </pattern>
+    # For containerd CRI (for EKS >= v1.24)
+    <pattern>
+      # format /^(?<time>.+) (?<stream>stdout|stderr) [^ ]* (?<log>.*)$/
+      format /^(?<time>.+) (?<stream>stdout|stderr) (?<logtag>[FP]) (?<log>.*)$/
+      time_format "%Y-%m-%dT%H:%M:%S.%N%:z"
+      keep_time_key true
+    </pattern>
   </parse>
 </source>
 
@@ -25,9 +36,12 @@
   <filter **>
     @type kubernetes_metadata
     @id filter_kube_metadata
+    # To improve CPU performance
     skip_labels true
+    skip_master_url true
+    skip_container_metadata true
   </filter>
-  # TODO: Parse nested JSON log messages
+  # Parse nested JSON log messages
   # https://github.com/repeatedly/fluent-plugin-multi-format-parser
   # https://docs.fluentd.org/filter/parser
   <filter **>


### PR DESCRIPTION
Due to recent changes in overall K8S container runtime, adding additional parsing rules to be able to process logs out of Docker and Containerd CRI.

https://docs.aws.amazon.com/eks/latest/userguide/dockershim-deprecation.html